### PR TITLE
Implement SmartLifecycle in RedisIndexedSessionRepository, ReactiveRe…

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
@@ -38,8 +38,8 @@ import reactor.core.scheduler.Schedulers;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.SmartLifecycle;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.core.NestedExceptionUtils;
 import org.springframework.data.redis.connection.ReactiveSubscription;
 import org.springframework.data.redis.core.ReactiveRedisOperations;
@@ -338,7 +338,7 @@ public class ReactiveRedisIndexedSessionRepository
 
 	private Flux<Void> cleanUpExpiredSessions() {
 		return this.expirationStore.retrieveExpiredSessions(this.clock.instant())
-				.filter(ignored -> isRunning())
+				.filter((ignored) -> isRunning())
 				.flatMap(this::touch);
 	}
 

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
@@ -251,6 +251,11 @@ public class ReactiveRedisIndexedSessionRepository
 	 */
 	public static final int DEFAULT_DATABASE = 0;
 
+	/**
+	* The default SmartLifeCycle phase
+	*/
+	public static final int DEFAULT_SMART_LIFECYCLE_PHASE = Integer.MAX_VALUE / 2;
+
 	private final ReactiveRedisOperations<String, Object> sessionRedisOperations;
 
 	private final ReactiveRedisTemplate<String, String> keyEventsOperations;
@@ -284,6 +289,8 @@ public class ReactiveRedisIndexedSessionRepository
 	private String namespace = DEFAULT_NAMESPACE + ":";
 
 	private int database = DEFAULT_DATABASE;
+
+	private int phase = DEFAULT_SMART_LIFECYCLE_PHASE;
 
 	private ReactiveRedisSessionIndexer indexer;
 
@@ -369,7 +376,11 @@ public class ReactiveRedisIndexedSessionRepository
 
 	@Override
 	public int getPhase() {
-		return 100;
+		return phase;
+	}
+
+	public void setPhase(int phase) {
+		this.phase = phase;
 	}
 
 	@Override

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
@@ -251,7 +251,24 @@ public class ReactiveRedisIndexedSessionRepository
 	public static final int DEFAULT_DATABASE = 0;
 
 	/**
-	 * The default SmartLifeCycle phase.
+	 * The default SmartLifecycle phase.
+	 *
+	 * <p>
+	 * Set to {@code Integer.MAX_VALUE / 2} to position this repository between the Redis
+	 * {@link org.springframework.data.redis.connection.RedisConnectionFactory} (typically
+	 * small, e.g. {@code 0}) and web server / messaging listener containers (very large
+	 * values, e.g. {@code Integer.MAX_VALUE - 1024}, {@code Integer.MAX_VALUE - 100},
+	 * {@code Integer.MAX_VALUE}), preventing shutdown races.
+	 * </p>
+	 *
+	 * <p>
+	 * <b>NOTE</b>: if the ConnectionFactory’s phase is >= this value, raise it via
+	 * {@link #setPhase(int)} to keep “SessionRepository phase > ConnectionFactory phase”.
+	 * </p>
+	 *
+	 * @see org.springframework.context.SmartLifecycle
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+	 * @see org.springframework.data.redis.connection.jedis.JedisConnectionFactory
 	 */
 	public static final int DEFAULT_SMART_LIFECYCLE_PHASE = Integer.MAX_VALUE / 2;
 

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
@@ -251,7 +251,7 @@ public class ReactiveRedisIndexedSessionRepository
 	public static final int DEFAULT_DATABASE = 0;
 
 	/**
-	 * The default SmartLifeCycle phase
+	 * The default SmartLifeCycle phase.
 	 */
 	public static final int DEFAULT_SMART_LIFECYCLE_PHASE = Integer.MAX_VALUE / 2;
 
@@ -381,7 +381,7 @@ public class ReactiveRedisIndexedSessionRepository
 
 	@Override
 	public int getPhase() {
-		return phase;
+		return this.phase;
 	}
 
 	public void setPhase(int phase) {

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepository.java
@@ -338,8 +338,8 @@ public class ReactiveRedisIndexedSessionRepository
 
 	private Flux<Void> cleanUpExpiredSessions() {
 		return this.expirationStore.retrieveExpiredSessions(this.clock.instant())
-				.filter((ignored) -> isRunning())
-				.flatMap(this::touch);
+			.filter((ignored) -> isRunning())
+			.flatMap(this::touch);
 	}
 
 	private Mono<Void> touch(String sessionId) {

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -289,7 +289,15 @@ public class RedisIndexedSessionRepository
 	 */
 	public static final String DEFAULT_NAMESPACE = "spring:session";
 
+	/**
+	 * The default SmartLifeCycle phase
+	 */
+	public static final int DEFAULT_SMART_LIFECYCLE_PHASE = Integer.MAX_VALUE / 2;
+
+
 	private int database = DEFAULT_DATABASE;
+
+	private int phase = DEFAULT_SMART_LIFECYCLE_PHASE;
 
 	/**
 	 * The namespace for every key used by Spring Session in Redis.
@@ -398,7 +406,11 @@ public class RedisIndexedSessionRepository
 
 	@Override
 	public int getPhase() {
-		return 100;
+		return phase;
+	}
+
+	public void setPhase(int phase) {
+		this.phase = phase;
 	}
 
 	/**

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -34,9 +34,9 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.SmartLifecycle;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.NonTransientDataAccessException;
 import org.springframework.data.redis.connection.Message;

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -289,7 +289,7 @@ public class RedisIndexedSessionRepository
 	public static final String DEFAULT_NAMESPACE = "spring:session";
 
 	/**
-	 * The default SmartLifeCycle phase
+	 * The default SmartLifeCycle phase.
 	 */
 	public static final int DEFAULT_SMART_LIFECYCLE_PHASE = Integer.MAX_VALUE / 2;
 
@@ -395,6 +395,7 @@ public class RedisIndexedSessionRepository
 			this.taskScheduler = null;
 		}
 
+		this.running = false;
 	}
 
 	@Override
@@ -409,7 +410,7 @@ public class RedisIndexedSessionRepository
 
 	@Override
 	public int getPhase() {
-		return phase;
+		return this.phase;
 	}
 
 	public void setPhase(int phase) {

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -289,7 +289,24 @@ public class RedisIndexedSessionRepository
 	public static final String DEFAULT_NAMESPACE = "spring:session";
 
 	/**
-	 * The default SmartLifeCycle phase.
+	 * The default SmartLifecycle phase.
+	 *
+	 * <p>
+	 * Set to {@code Integer.MAX_VALUE / 2} to position this repository between the Redis
+	 * {@link org.springframework.data.redis.connection.RedisConnectionFactory} (typically
+	 * small, e.g. {@code 0}) and web server / messaging listener containers (very large
+	 * values, e.g. {@code Integer.MAX_VALUE - 1024}, {@code Integer.MAX_VALUE - 100},
+	 * {@code Integer.MAX_VALUE}), preventing shutdown races.
+	 * </p>
+	 *
+	 * <p>
+	 * <b>NOTE</b>: if the ConnectionFactory’s phase is >= this value, raise it via
+	 * {@link #setPhase(int)} to keep “SessionRepository phase > ConnectionFactory phase”.
+	 * </p>
+	 *
+	 * @see org.springframework.context.SmartLifecycle
+	 * @see org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+	 * @see org.springframework.data.redis.connection.jedis.JedisConnectionFactory
 	 */
 	public static final int DEFAULT_SMART_LIFECYCLE_PHASE = Integer.MAX_VALUE / 2;
 

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepositoryTests.java
@@ -51,7 +51,8 @@ class ReactiveRedisIndexedSessionRepositoryTests {
 
 	@BeforeEach
 	void setup() {
-		this.repository = new ReactiveRedisIndexedSessionRepository(this.sessionRedisOperations, this.keyEventsOperations);
+		this.repository = new ReactiveRedisIndexedSessionRepository(this.sessionRedisOperations,
+				this.keyEventsOperations);
 	}
 
 	@Test
@@ -141,8 +142,7 @@ class ReactiveRedisIndexedSessionRepositoryTests {
 
 		Flux<Void> result = invokeCleanUpExpiredSessions();
 
-		StepVerifier.create(result)
-				.verifyComplete();
+		StepVerifier.create(result).verifyComplete();
 	}
 
 	@Test
@@ -155,8 +155,7 @@ class ReactiveRedisIndexedSessionRepositoryTests {
 
 		Flux<Void> result = invokeCleanUpExpiredSessions();
 
-		StepVerifier.create(result)
-				.verifyComplete();
+		StepVerifier.create(result).verifyComplete();
 	}
 
 	@Test

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepositoryTests.java
@@ -16,10 +16,6 @@
 
 package org.springframework.session.data.redis;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-
 import java.time.Duration;
 import java.util.List;
 
@@ -28,13 +24,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
 import org.springframework.data.redis.core.ReactiveRedisOperations;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import reactor.core.Disposable;
-import reactor.core.publisher.Flux;
-import reactor.test.StepVerifier;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ReactiveRedisIndexedSessionRepositoryTests {
@@ -113,7 +115,7 @@ class ReactiveRedisIndexedSessionRepositoryTests {
 		List<Disposable> subscriptions = getSubscriptions();
 		assertThat(subscriptions).isNotEmpty();
 
-		subscriptions.forEach(sub -> assertThat(sub.isDisposed()).isFalse());
+		subscriptions.forEach((sub) -> assertThat(sub.isDisposed()).isFalse());
 	}
 
 	@Test
@@ -127,7 +129,7 @@ class ReactiveRedisIndexedSessionRepositoryTests {
 
 		this.repository.stop();
 
-		subscriptionsBeforeStop.forEach(sub -> assertThat(sub.isDisposed()).isTrue());
+		subscriptionsBeforeStop.forEach((sub) -> assertThat(sub.isDisposed()).isTrue());
 
 		List<Disposable> subscriptionsAfterStop = getSubscriptions();
 		assertThat(subscriptionsAfterStop).isEmpty();
@@ -223,7 +225,7 @@ class ReactiveRedisIndexedSessionRepositoryTests {
 
 		List<Disposable> subscriptions = getSubscriptions();
 		assertThat(subscriptions).isNotEmpty();
-		subscriptions.forEach(sub -> assertThat(sub.isDisposed()).isFalse());
+		subscriptions.forEach((sub) -> assertThat(sub.isDisposed()).isFalse());
 	}
 
 	private void givenSubscriptionsNever() {
@@ -244,7 +246,8 @@ class ReactiveRedisIndexedSessionRepositoryTests {
 	private Flux<Void> invokeCleanUpExpiredSessions() {
 		try {
 			return ReflectionTestUtils.invokeMethod(this.repository, "cleanUpExpiredSessions");
-		} catch (Exception e) {
+		}
+		catch (Exception ex) {
 			return Flux.empty();
 		}
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepositoryTests.java
@@ -103,7 +103,9 @@ class ReactiveRedisIndexedSessionRepositoryTests {
 	}
 
 	@Test
-	void getPhaseShouldReturn100() {
+	void getPhaseShouldReturnPhase() {
+		this.repository.setPhase(100);
+
 		assertThat(this.repository.getPhase()).isEqualTo(100);
 	}
 

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisIndexedSessionRepositoryTests.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2014-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.data.redis;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ReactiveRedisOperations;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class ReactiveRedisIndexedSessionRepositoryTests {
+
+	@Mock
+	private ReactiveRedisOperations<String, Object> sessionRedisOperations;
+
+	@Mock
+	private ReactiveRedisTemplate<String, String> keyEventsOperations;
+
+	private ReactiveRedisIndexedSessionRepository repository;
+
+	@BeforeEach
+	void setup() {
+		this.repository = new ReactiveRedisIndexedSessionRepository(this.sessionRedisOperations, this.keyEventsOperations);
+	}
+
+	@Test
+	void startShouldSetRunningTrue() {
+		givenSubscriptionsEmpty();
+
+		this.repository.start();
+
+		assertThat(this.repository.isRunning()).isTrue();
+	}
+
+	@Test
+	void startShouldBeIdempotent() {
+		givenSubscriptionsEmpty();
+
+		this.repository.start();
+		this.repository.start();
+
+		assertThat(this.repository.isRunning()).isTrue();
+
+		verify(this.sessionRedisOperations, times(1)).listenToPattern(anyString());
+		verify(this.keyEventsOperations, times(1)).listenToChannel(anyString(), anyString());
+	}
+
+	@Test
+	void stopShouldSetRunningFalse() {
+		givenSubscriptionsEmpty();
+
+		this.repository.start();
+		this.repository.stop();
+
+		assertThat(this.repository.isRunning()).isFalse();
+	}
+
+	@Test
+	void stopShouldBeIdempotent() {
+		givenSubscriptionsEmpty();
+
+		this.repository.start();
+		this.repository.stop();
+		this.repository.stop();
+		assertThat(this.repository.isRunning()).isFalse();
+	}
+
+	@Test
+	void isAutoStartupShouldReturnTrue() {
+		assertThat(this.repository.isAutoStartup()).isTrue();
+	}
+
+	@Test
+	void getPhaseShouldReturn100() {
+		assertThat(this.repository.getPhase()).isEqualTo(100);
+	}
+
+	@Test
+	void startShouldCreateSubscriptions() {
+		givenSubscriptionsNever();
+
+		this.repository.start();
+
+		List<Disposable> subscriptions = getSubscriptions();
+		assertThat(subscriptions).isNotEmpty();
+
+		subscriptions.forEach(sub -> assertThat(sub.isDisposed()).isFalse());
+	}
+
+	@Test
+	void stopShouldDisposeAllSubscriptions() {
+		givenSubscriptionsEmpty();
+
+		this.repository.start();
+
+		List<Disposable> subscriptionsBeforeStop = getSubscriptions();
+		assertThat(subscriptionsBeforeStop).isNotEmpty();
+
+		this.repository.stop();
+
+		subscriptionsBeforeStop.forEach(sub -> assertThat(sub.isDisposed()).isTrue());
+
+		List<Disposable> subscriptionsAfterStop = getSubscriptions();
+		assertThat(subscriptionsAfterStop).isEmpty();
+	}
+
+	@Test
+	void cleanUpExpiredSessionsShouldRespectRunningState() {
+		this.repository.stop();
+
+		Flux<Void> result = invokeCleanUpExpiredSessions();
+
+		StepVerifier.create(result)
+				.verifyComplete();
+	}
+
+	@Test
+	void cleanUpExpiredSessionsWhenRunning() {
+		givenSubscriptionsEmpty();
+
+		this.repository.start();
+
+		assertThat(this.repository.isRunning()).isTrue();
+
+		Flux<Void> result = invokeCleanUpExpiredSessions();
+
+		StepVerifier.create(result)
+				.verifyComplete();
+	}
+
+	@Test
+	void destroyShouldCallStop() {
+		givenSubscriptionsEmpty();
+
+		this.repository.start();
+		this.repository.destroy();
+		assertThat(this.repository.isRunning()).isFalse();
+	}
+
+	@Test
+	void afterPropertiesSetShouldCallStart() throws Exception {
+		givenSubscriptionsEmpty();
+
+		this.repository.afterPropertiesSet();
+		assertThat(this.repository.isRunning()).isTrue();
+	}
+
+	@Test
+	void cleanupIntervalZeroShouldNotCreateCleanupTask() {
+		givenSubscriptionsEmpty();
+
+		this.repository.setCleanupInterval(Duration.ZERO);
+		this.repository.start();
+
+		List<Disposable> subscriptions = getSubscriptions();
+
+		assertThat(subscriptions).hasSize(2);
+	}
+
+	@Test
+	void cleanupIntervalNonZeroShouldCreateCleanupTask() {
+		givenSubscriptionsEmpty();
+
+		this.repository.setCleanupInterval(Duration.ofSeconds(10));
+		this.repository.start();
+
+		List<Disposable> subscriptions = getSubscriptions();
+
+		assertThat(subscriptions).hasSize(3);
+	}
+
+	@Test
+	void stopWhenNotRunningNotDisposeSubscriptions() {
+		this.repository.stop();
+
+		assertThat(this.repository.isRunning()).isFalse();
+
+		List<Disposable> subscriptions = getSubscriptions();
+		assertThat(subscriptions).isEmpty();
+	}
+
+	@Test
+	void multipleStartStopCyclesShouldWorkCorrectly() {
+		givenSubscriptionsNever();
+
+		this.repository.start();
+		assertThat(this.repository.isRunning()).isTrue();
+
+		this.repository.stop();
+		assertThat(this.repository.isRunning()).isFalse();
+
+		this.repository.start();
+		assertThat(this.repository.isRunning()).isTrue();
+
+		List<Disposable> subscriptions = getSubscriptions();
+		assertThat(subscriptions).isNotEmpty();
+		subscriptions.forEach(sub -> assertThat(sub.isDisposed()).isFalse());
+	}
+
+	private void givenSubscriptionsNever() {
+		given(this.sessionRedisOperations.listenToPattern(anyString())).willReturn(Flux.never());
+		given(this.keyEventsOperations.listenToChannel(anyString(), anyString())).willReturn(Flux.never());
+	}
+
+	private void givenSubscriptionsEmpty() {
+		given(this.sessionRedisOperations.listenToPattern(anyString())).willReturn(Flux.empty());
+		given(this.keyEventsOperations.listenToChannel(anyString(), anyString())).willReturn(Flux.empty());
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<Disposable> getSubscriptions() {
+		return (List<Disposable>) ReflectionTestUtils.getField(this.repository, "subscriptions");
+	}
+
+	private Flux<Void> invokeCleanUpExpiredSessions() {
+		try {
+			return ReflectionTestUtils.invokeMethod(this.repository, "cleanUpExpiredSessions");
+		} catch (Exception e) {
+			return Flux.empty();
+		}
+	}
+
+}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
@@ -449,6 +449,8 @@ class RedisIndexedSessionRepositoryTests {
 		Set<Object> expiredIds = new HashSet<>(Arrays.asList("expired-key1", "expired-key2"));
 		given(this.boundSetOperations.members()).willReturn(expiredIds);
 
+		this.redisRepository.start();
+
 		this.redisRepository.cleanUpExpiredSessions();
 
 		for (Object id : expiredIds) {
@@ -773,6 +775,58 @@ class RedisIndexedSessionRepositoryTests {
 		this.redisRepository.setCleanupCron(Scheduled.CRON_DISABLED);
 		this.redisRepository.afterPropertiesSet();
 		assertThat(this.redisRepository).extracting("taskScheduler").isNull();
+	}
+
+	@Test
+	void startShouldSetRunningTrue() {
+		this.redisRepository.start();
+		assertThat(this.redisRepository.isRunning()).isTrue();
+	}
+
+	@Test
+	void startShouldBeIdempotent() {
+		this.redisRepository.start();
+		this.redisRepository.start();
+		assertThat(this.redisRepository.isRunning()).isTrue();
+	}
+
+	@Test
+	void stopShouldSetRunningFalse() {
+		this.redisRepository.start();
+		this.redisRepository.stop();
+		assertThat(this.redisRepository.isRunning()).isFalse();
+	}
+
+	@Test
+	void stopShouldBeIdempotent() {
+		this.redisRepository.start();
+		this.redisRepository.stop();
+		this.redisRepository.stop();
+		assertThat(this.redisRepository.isRunning()).isFalse();
+	}
+
+	@Test
+	void isAutoStartupShouldReturnTrue() {
+		assertThat(this.redisRepository.isAutoStartup()).isTrue();
+	}
+
+	@Test
+	void getPhaseShouldReturn100() {
+		assertThat(this.redisRepository.getPhase()).isEqualTo(100);
+	}
+
+	@Test
+	void cleanUpExpiredSessionsShouldRespectRunningState() {
+		this.redisRepository.stop();
+		this.redisRepository.cleanUpExpiredSessions();
+		verifyNoMoreInteractions(this.redisOperations);
+	}
+
+	@Test
+	void destroyShouldCallStop() {
+		this.redisRepository.start();
+		this.redisRepository.destroy();
+		assertThat(this.redisRepository.isRunning()).isFalse();
 	}
 
 	@Test

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
@@ -811,7 +811,9 @@ class RedisIndexedSessionRepositoryTests {
 	}
 
 	@Test
-	void getPhaseShouldReturn100() {
+	void getPhaseShouldReturnPhase() {
+		this.redisRepository.setPhase(100);
+
 		assertThat(this.redisRepository.getPhase()).isEqualTo(100);
 	}
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Summary
애플리케이션 종료 시 올바른 종료 순서를 보장하고 Redis 연결 오류를 방지하기 위해 SmartLifecycle 인터페이스를 구현했습니다.

이슈:  https://github.com/spring-projects/spring-session/issues/3435
문제현상 재현 프로젝트: https://github.com/seung-hun-h/redis-test

Changes
- getPhase() = 100인 SmartLifecycle을 추가하여 ConnectionFactory보다 먼저 종료되도록 함
- AtomicBoolean running을 사용해 스레드 안전한 상태 관리 구현
- SmartLifeCycle 기능에 대한 단위 테스트 추가

Question
- `DisposableBean`을 일단 유지하는 방향으로 구현했습니다. 제거하는 방향으로 진행할지 고민이됩니다.
- `SmartLifeCycle`을 구현하면서 `InitializingBean`의 기능도 그대로 마이그레이션했습니다. `InitializingBean`도 `DisposableBean`와 마찬가지로 제거하는 방향으로 진행할지 고민이됩니다